### PR TITLE
Base url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,6 @@ ENV HOME /home/pyxie
 ENV SHELL /bin/bash
 ENV USER pyxie
 
+EXPOSE 8888
+
 WORKDIR /home/pyxie

--- a/jupyter-kernel.py
+++ b/jupyter-kernel.py
@@ -83,6 +83,11 @@ class WebApp(web.Application):
 
     def __init__(self, kernel_manager, base_path):
 
+        if not base_path.startswith('/'):
+            base_path = '/' + base_path
+        if not base_path.endswith('/'):
+            base_path = base_path + '/'
+
         app_log.info("Routing on {}".format(base_path))
         handlers = [
             (url_path_join(base_path, r"/"), IndexHandler),

--- a/jupyter-kernel.py
+++ b/jupyter-kernel.py
@@ -28,6 +28,7 @@ import os
 from distutils.version import LooseVersion
 
 import IPython
+from IPython.html.utils import url_path_join
 
 try:
     if LooseVersion(IPython.__version__) < LooseVersion('1.0'):
@@ -76,16 +77,15 @@ class IndexHandler(web.RequestHandler):
         self.write("Hello world")
 
 class WebApp(web.Application):
-	
 
-    def __init__(self, kernel_manager):
+    def __init__(self, kernel_manager, base_path):
         handlers = [
-            (r"/", IndexHandler),
-            (r"/kernels/%s" % _kernel_id_regex, KernelHandler),
-            (r"/kernels/%s/%s" % (_kernel_id_regex, _kernel_action_regex), KernelActionHandler),
-            (r"/kernels/%s/iopub" % _kernel_id_regex, IOPubHandler),
-            (r"/kernels/%s/shell" % _kernel_id_regex, ShellHandler),
-            (r"/kernels/%s/stdin" % _kernel_id_regex, StdinHandler),
+            (url_path_join(base_path, r"/"), IndexHandler),
+            (url_path_join(base_path, r"/kernels/%s" % _kernel_id_regex), KernelHandler),
+            (url_path_join(base_path, r"/kernels/%s/%s" % (_kernel_id_regex, _kernel_action_regex)), KernelActionHandler),
+            (url_path_join(base_path, r"/kernels/%s/iopub" % _kernel_id_regex), IOPubHandler),
+            (url_path_join(base_path, r"/kernels/%s/shell" % _kernel_id_regex), ShellHandler),
+            (url_path_join(base_path, r"/kernels/%s/stdin" % _kernel_id_regex), StdinHandler),
         ]
 
         # Python < 2.6.5 doesn't accept unicode keys in f(**kwargs), and
@@ -103,6 +103,8 @@ class WebApp(web.Application):
             cookie_secret='secret',
             cookie_name='ignored',
             kernel_manager=kernel_manager,
+            base_path=base_path,
+            static_url_prefix=url_path_join(base_path, '/static/'),
         )
 
         super(WebApp, self).__init__(handlers, **settings)
@@ -127,6 +129,12 @@ StdinHandler.check_origin = check_origin
 
 def main():
 
+    tornado.options.define('base_url', default='/',
+            help="Base URL for the server (e.g. /singlecell)"
+    )
+    tornado.options.parse_command_line()
+    opts = tornado.options.options
+
     kernel_manager = MultiKernelManager()
     
 	
@@ -135,7 +143,7 @@ def main():
     kernel_manager.start_kernel(kernel_id=kernel_id)
     
     logging.basicConfig(level=logging.INFO)
-    app = WebApp(kernel_manager)
+    app = WebApp(kernel_manager, opts.base_url)
 
     server = httpserver.HTTPServer(app)
     server.listen(8888, '0.0.0.0')

--- a/jupyter-kernel.py
+++ b/jupyter-kernel.py
@@ -43,6 +43,9 @@ except TypeError:
 from zmq.eventloop import ioloop
 ioloop.install()
 
+import tornado
+import tornado.options
+
 from tornado import httpserver
 from tornado import web
 

--- a/jupyter-kernel.py
+++ b/jupyter-kernel.py
@@ -129,8 +129,8 @@ StdinHandler.check_origin = check_origin
 
 def main():
 
-    tornado.options.define('base_url', default='/',
-            help="Base URL for the server (e.g. /singlecell)"
+    tornado.options.define('base_path', default='/',
+            help="Base path for the server (e.g. /singlecell)"
     )
     tornado.options.parse_command_line()
     opts = tornado.options.options
@@ -143,7 +143,7 @@ def main():
     kernel_manager.start_kernel(kernel_id=kernel_id)
     
     logging.basicConfig(level=logging.INFO)
-    app = WebApp(kernel_manager, opts.base_url)
+    app = WebApp(kernel_manager, opts.base_path)
 
     server = httpserver.HTTPServer(app)
     server.listen(8888, '0.0.0.0')

--- a/jupyter-kernel.py
+++ b/jupyter-kernel.py
@@ -82,6 +82,8 @@ class IndexHandler(web.RequestHandler):
 class WebApp(web.Application):
 
     def __init__(self, kernel_manager, base_path):
+
+        app_log.info("Routing on {}".format(base_path))
         handlers = [
             (url_path_join(base_path, r"/"), IndexHandler),
             (url_path_join(base_path, r"/kernels/%s" % _kernel_id_regex), KernelHandler),
@@ -90,6 +92,8 @@ class WebApp(web.Application):
             (url_path_join(base_path, r"/kernels/%s/shell" % _kernel_id_regex), ShellHandler),
             (url_path_join(base_path, r"/kernels/%s/stdin" % _kernel_id_regex), StdinHandler),
         ]
+
+        app_log.info("{}".format(handlers))
 
         # Python < 2.6.5 doesn't accept unicode keys in f(**kwargs), and
         # base_project_url will always be unicode, which will in turn


### PR DESCRIPTION
This sets up a base path so that this jupyter kernel server can be:
- Routed on a proxy (proxy_pass in nginx land)
- Run on [tmpnb](https://github.com/jupyter/tmpnb)

To get this running with tmpnb, I used roughly the same setup you had on your demo server and README:

``` console
$ docker rm -f $( docker ps -aq ) #Optional: just used to clean up house
$ docker build -t odewahn/jupyter-kernel .
$ # Make sure to run the proxy with the same $TOKEN as tmpnb
$ docker run --net=host -d -e CONFIGPROXY_AUTH_TOKEN=$TOKEN --name=proxy \
                  jupyter/configurable-http-proxy --default-target http://127.0.0.1:9999
$ docker run --net=host -e CONFIGPROXY_AUTH_TOKEN=$TOKEN \
   -v /var/run/docker.sock:/docker.sock \
   jupyter/tmpnb \
   python orchestrate.py --container_ip=0.0.0.0 --image="odewahn/jupyter-kernel" \
   --command="python jupyter-kernel.py --base_path='{base_path}'" --pool_size=5 --redirect-uri="/"
```

The differences here for running it include the use of `base_path` to allow tmpnb to inform this project/server that it will be routed on `base_path`. Additionally, I've set the `redirect-uri` to '/' so that it takes the user to the base page.
