### PR TITLE
Updated vagrant box url to work with vmware and virtualbox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,9 +11,8 @@ SCRIPT
 
 
 Vagrant.configure("2") do |config|
-  
-  config.vm.box = 'precise64'
-  config.vm.box_url = 'http://files.vagrantup.com/precise64.box'
+
+  config.vm.box = "hashicorp/precise64"
   config.vm.network :forwarded_port, guest: 8000, host: 8000
   config.vm.network :forwarded_port, guest: 8888, host: 8888
   config.vm.provision "shell", inline: $script


### PR DESCRIPTION
Now uses `config.vm.box = "hashicorp/precise64"`
